### PR TITLE
Fix for URL which contains question mark 

### DIFF
--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -53,10 +53,15 @@ class SamlSso implements SamlContract
         $this->authn_request = new AuthnRequest;
         $this->authn_request->deserialize($deserializationContext->getDocument()->firstChild, $deserializationContext);
 
-        $this->destination = config(sprintf(
+        $destination = config(sprintf(
             'samlidp.sp.%s.destination',
             $this->getServiceProvider($this->authn_request)
-        )) . '?idp=' . config('app.url');
+        ));
+        $parsedUrl = parse_url($destination);
+        parse_str($parsedUrl['query'], $parsedQueryParams);
+        $parsedQueryParams['idp'] = config('app.url');
+
+        $this->destination = strtok($destination, '?') . '?' . http_build_query($parsedQueryParams);
 
         return $this->response();
     }


### PR DESCRIPTION
If there is an URL which contains question mark in it (like for example http://localhost:8181/wp-login.php?saml_acs in wordpress plugin) concatenation of ?idp makes wron URL in response destination.