### PR TITLE
Fixing destination modification assumptions

### DIFF
--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -33,9 +33,10 @@ return [
         // Base64 encoded ACS URL
         // 'aHR0cHM6Ly9teWZhY2Vib29rd29ya3BsYWNlLmZhY2Vib29rLmNvbS93b3JrL3NhbWwucGhw' => [
         //     // Your destination is the ACS URL of the Service Provider
-        //     'destination' => 'https://myfacebookworkplace.facebook.com/work/saml.php'
-        //     'logout' => 'https://myfacebookworkplace.facebook.com/work/sls.php'
-        //     'certificate' => ''
+        //     'destination' => 'https://myfacebookworkplace.facebook.com/work/saml.php',
+        //     'logout' => 'https://myfacebookworkplace.facebook.com/work/sls.php',
+        //     'certificate' => '',
+        //     'query_params' => false
         // ]
     ],
 

--- a/src/Jobs/SamlSlo.php
+++ b/src/Jobs/SamlSlo.php
@@ -14,6 +14,8 @@ use LightSaml\Model\Protocol\Status;
 use LightSaml\Model\Protocol\StatusCode;
 use LightSaml\Model\XmlDSig\SignatureWriter;
 use LightSaml\SamlConstants;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class SamlSlo
 {
@@ -98,10 +100,24 @@ class SamlSlo
     private function setDestination()
     {
         $destination = $this->sp['logout'];
-        $parsed_url = parse_url($destination);
-        parse_str($parsed_url['query'] ?? '', $parsed_query_params);
-        $parsed_query_params['idp'] = config('app.url');
+        $queryParams = $this->getQueryParams();
+        if (!empty($queryParams)) {
+            $destination = Str::finish(url($destination), '?') . Arr::query($queryParams);
+        }
 
-        $this->destination = strtok($destination, '?') . '?' . http_build_query($parsed_query_params);
+        $this->destination = $destination;
     }
+ 
+   private function getQueryParams()
+   {
+        $queryParams = (isset($this->sp['query_params']) ? $this->sp['query_params'] : null);
+
+        if (is_null($queryParams)) {
+            $queryParams = [
+                'idp' => config('app.url')
+            ];
+        }
+
+        return $queryParams;
+   }
 }

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -30,7 +30,6 @@ use LightSaml\Model\Protocol\Status;
 use LightSaml\Model\Protocol\StatusCode;
 use LightSaml\Model\XmlDSig\SignatureWriter;
 use LightSaml\SamlConstants;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -154,15 +154,10 @@ class SamlSso implements SamlContract
 
     private function setDestination()
     {
-        $destination = config(sprintf(
+        $this->destination = config(sprintf(
             'samlidp.sp.%s.destination',
             $this->getServiceProvider($this->authn_request)
         ));
-        $parsed_url = parse_url($destination);
-        parse_str($parsed_url['query'] ?? '', $parsed_query_params);
-        $parsed_query_params['idp'] = config('app.url');
-
-        $this->destination = strtok($destination, '?') . '?' . http_build_query($parsed_query_params);
     }
 
     public function setSpCertificate()


### PR DESCRIPTION
While this is breaking for applications that depends on the ldp parameter, there should not be any assumptions that it should be included, as it causes implementations with simplesamlserver and google to fail. If the destination address requires the parameter to be set, it should be manually set in the applications config options.