### PR TITLE
Fix the problem of urls that have a query parameters

### DIFF
--- a/src/Jobs/SamlSlo.php
+++ b/src/Jobs/SamlSlo.php
@@ -102,7 +102,12 @@ class SamlSlo
         $destination = $this->sp['logout'];
         $queryParams = $this->getQueryParams();
         if (!empty($queryParams)) {
-            $destination = Str::finish(url($destination), '?') . Arr::query($queryParams);
+            if (!parse_url($destination, PHP_URL_QUERY)){
+                $destination = Str::finish(url($destination), '?') . Arr::query($queryParams);
+            }
+            else{
+                $destination .= '&'.Arr::query($queryParams);
+            }
         }
 
         $this->destination = $destination;

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -174,7 +174,12 @@ class SamlSso implements SamlContract
 
         $queryParams = $this->getQueryParams();
         if (!empty($queryParams)) {
-            $destination = Str::finish(url($destination), '?') . Arr::query($queryParams);
+            if (!parse_url($destination, PHP_URL_QUERY)){
+                $destination = Str::finish(url($destination), '?') . Arr::query($queryParams);
+            }
+            else{
+                $destination .= '&'.Arr::query($queryParams);
+            }
         }
 
         $this->destination = $destination;


### PR DESCRIPTION
This will fix the problem of `acs` or `slo` that have query params like for example `https://domain.com/login?saml_sso`. As of the current implementation the redirect will be like `https://domain.com/login?saml_sso?idp=idp.com`.