### PR TITLE
Get E-Mail from field defined in the config

### DIFF
--- a/src/Events/Assertion.php
+++ b/src/Events/Assertion.php
@@ -29,7 +29,7 @@ class Assertion
     {
         $this->attribute_statement = &$attribute_statement;
         $this->attribute_statement
-            ->addAttribute(new Attribute(ClaimTypes::EMAIL_ADDRESS, auth()->user()->email))
+            ->addAttribute(new Attribute(ClaimTypes::EMAIL_ADDRESS, auth()->user()->__get(config('samlidp.email_field', 'email'))))
             ->addAttribute(new Attribute(ClaimTypes::COMMON_NAME, auth()->user()->name));
     }
 }

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -81,7 +81,7 @@ class SamlSso implements SamlContract
             ->setSignature(new SignatureWriter($this->certificate, $this->private_key))
             ->setSubject(
                 (new Subject)
-                    ->setNameID((new NameID(auth()->user()->email, SamlConstants::NAME_ID_FORMAT_EMAIL)))
+                    ->setNameID((new NameID(auth()->user()->__get(config('samlidp.email_field', 'email')), SamlConstants::NAME_ID_FORMAT_EMAIL)))
                     ->addSubjectConfirmation(
                         (new SubjectConfirmation)
                             ->setMethod(SamlConstants::CONFIRMATION_METHOD_BEARER)


### PR DESCRIPTION
Hey Code Green Creative,

Ran into an issue today on a Laravel app where the 'email' column didn't exist.  In the config file, I had the 'email_field' changed, but when I tried to login, would get "NameID value not set".

(Temporary workaround - creating a getEmailAttribute() get method on the my User model)

