### PR TITLE
@samlidp Blade component's IF statement if only evaluated on first page load

### DIFF
--- a/src/LaravelSamlIdpServiceProvider.php
+++ b/src/LaravelSamlIdpServiceProvider.php
@@ -88,9 +88,7 @@ class LaravelSamlIdpServiceProvider extends ServiceProvider
     public function registerBladeComponents()
     {
         Blade::directive('samlidp', function ($expression) {
-            if (request()->filled('SAMLRequest')) {
-                return "<?php echo view('samlidp::components.input'); ?>";
-            }
+            return "<?php echo request()->filled('SAMLRequest') ? view('samlidp::components.input') : ''; ?>";
         });
     }
 


### PR DESCRIPTION
Hello!

Blade directives cache the PHP string on the first occurrence. In your `@samlidp` component, the IF statement checking for a `SAMLRequest` parameter is only checked on the first load. This can cause issues for applications that share the login form with their SAML login.