### PR TITLE
Register events from the config file

### DIFF
--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -46,6 +46,20 @@ return [
         // 'https://example.com' => 'https://example.com',
     ],
 
-    // List of guards saml idp will catch Authenticated, Login and Logout events 
-    'guards' => ['web']
+    // List of guards saml idp will catch Authenticated, Login and Logout events
+    'guards' => ['web'],
+
+    // All of the Laravel SAML IdP event / listener mappings.
+    'events' => [
+        'CodeGreenCreative\SamlIdp\Events\Assertion' => [],
+        'Illuminate\Auth\Events\Logout' => [
+            'CodeGreenCreative\SamlIdp\Listeners\SamlLogout',
+        ],
+        'Illuminate\Auth\Events\Authenticated' => [
+            'CodeGreenCreative\SamlIdp\Listeners\SamlAuthenticated',
+        ],
+        'Illuminate\Auth\Events\Login' => [
+            'CodeGreenCreative\SamlIdp\Listeners\SamlLogin',
+        ],
+    ],
 ];

--- a/src/LaravelSamlIdpServiceProvider.php
+++ b/src/LaravelSamlIdpServiceProvider.php
@@ -109,7 +109,7 @@ class LaravelSamlIdpServiceProvider extends ServiceProvider
     private function registerEvents()
     {
         $events = $this->app->make(Dispatcher::class);
-        foreach (config('samlidp.events') as $event => $listeners) {
+        foreach (config('samlidp.events', $this->default_events) as $event => $listeners) {
             foreach ($listeners as $listener) {
                 $events->listen($event, $listener);
             }

--- a/src/LaravelSamlIdpServiceProvider.php
+++ b/src/LaravelSamlIdpServiceProvider.php
@@ -109,7 +109,7 @@ class LaravelSamlIdpServiceProvider extends ServiceProvider
     private function registerEvents()
     {
         $events = $this->app->make(Dispatcher::class);
-        foreach ($this->events as $event => $listeners) {
+        foreach (config('samlidp.events') as $event => $listeners) {
             foreach ($listeners as $listener) {
                 $events->listen($event, $listener);
             }

--- a/src/Traits/EventMap.php
+++ b/src/Traits/EventMap.php
@@ -9,7 +9,7 @@ trait EventMap
      *
      * @var array
      */
-    protected $events = [
+    protected $default_events = [
         'CodeGreenCreative\SamlIdp\Events\Assertion' => [],
         'Illuminate\Auth\Events\Logout' => [
             'CodeGreenCreative\SamlIdp\Listeners\SamlLogout',


### PR DESCRIPTION
This will allow the developer to configure the events of samlidp easily. And also in the current state of laravel it does not cache the events registered throw the packages, so this will allow the user of the package to register the events manually in the [EventServiceProvider ](https://github.com/laravel/laravel/blob/0e8e9a0727afce37d6954a9763a86dde82eb99ee/app/Providers/EventServiceProvider.php#L17) to be cached.