### PR TITLE
adding in security digest

### DIFF
--- a/src/Jobs/SamlSlo.php
+++ b/src/Jobs/SamlSlo.php
@@ -71,7 +71,7 @@ class SamlSlo
             ->setStatus(new Status(new StatusCode('urn:oasis:names:tc:SAML:2.0:status:Success')));
 
         if (config('samlidp.messages_signed')) {
-            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key));
+            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm));
         }
 
         return $this->send(SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
@@ -91,7 +91,7 @@ class SamlSlo
             ->setDestination($this->destination);
 
         if (config('samlidp.messages_signed')) {
-            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key));
+            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm));
         }
 
         return $this->send(SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
@@ -107,7 +107,7 @@ class SamlSlo
 
         $this->destination = $destination;
     }
- 
+
    private function getQueryParams()
    {
         $queryParams = (isset($this->sp['query_params']) ? $this->sp['query_params'] : null);

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -77,7 +77,7 @@ class SamlSso implements SamlContract
             ->setId(Helper::generateID())
             ->setIssueInstant(new \DateTime)
             ->setIssuer(new Issuer($this->issuer))
-            ->setSignature(new SignatureWriter($this->certificate, $this->private_key))
+            ->setSignature(new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm))
             ->setSubject(
                 (new Subject)
                     ->setNameID((new NameID(auth()->user()->email, SamlConstants::NAME_ID_FORMAT_EMAIL)))
@@ -129,7 +129,7 @@ class SamlSso implements SamlContract
         }
 
         if (config('samlidp.messages_signed')) {
-            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key));
+            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm));
         }
 
         return $this->send(SamlConstants::BINDING_SAML2_HTTP_POST);

--- a/src/Traits/PerformsSingleSignOn.php
+++ b/src/Traits/PerformsSingleSignOn.php
@@ -7,6 +7,7 @@ use LightSaml\Binding\BindingFactory;
 use LightSaml\Context\Profile\MessageContext;
 use LightSaml\Credential\KeyHelper;
 use LightSaml\Credential\X509Certificate;
+use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 trait PerformsSingleSignOn
@@ -16,6 +17,7 @@ trait PerformsSingleSignOn
     private $private_key;
     private $request;
     private $response;
+    private $digest_algorithm;
 
     /**
      * [__construct description]
@@ -26,6 +28,7 @@ trait PerformsSingleSignOn
         $this->certificate = (new X509Certificate)->loadPem(Storage::disk('samlidp')->get(config('samlidp.certname', 'cert.pem')));
         $this->private_key = Storage::disk('samlidp')->get(config('samlidp.keyname', 'key.pem'));
         $this->private_key = KeyHelper::createPrivateKey($this->private_key, '', false, XMLSecurityKey::RSA_SHA256);
+        $this->digest_algorithm = config('samlidp.digest_algorithm', XMLSecurityDSig::SHA1);
     }
 
     /**


### PR DESCRIPTION
Currently the hashing algorithm will always be SHA1 (which is the default when setting the signature in lightsail)

this allows you to set a hashing algorithm from the config file such as 


    // Make sure messages are signed
    'messages_signed' => false,
    // Signature Digest Algorithm
    **'digest_algorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',**
    // list of all service providers
    'sp' => [
    
    This allows you to select any algrithim that light sail supports,
    
    It defaults to SHA1 so no ones code will break
    