### PR TITLE
Change AuthnContext to use a better AUTHN_CONTEXT_UNSPECIFIED context

### DIFF
--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -107,7 +107,7 @@ class SamlSso implements SamlContract
                     ->setSessionIndex(Helper::generateID())
                     ->setAuthnContext(
                         (new AuthnContext)
-                            ->setAuthnContextClassRef(SamlConstants::NAME_ID_FORMAT_UNSPECIFIED)
+                            ->setAuthnContextClassRef(SamlConstants::AUTHN_CONTEXT_UNSPECIFIED)
                     )
             );
 


### PR DESCRIPTION
Resolves #59 by changing the constant used to a better option as I explained in the issue.