### PR TITLE
Strip whitespace before certificate cleanup

### DIFF
--- a/src/Http/Controllers/MetadataController.php
+++ b/src/Http/Controllers/MetadataController.php
@@ -20,6 +20,7 @@ class MetadataController extends Controller
         }
 
         $cert = Storage::disk('samlidp')->get(config('samlidp.certname', 'cert.pem'));
+        $cert = trim($cert);
         $cert = preg_replace('/^\W+\w+\s+\w+\W+\s(.*)\s+\W+.*$/s', '$1', $cert);
         $cert = str_replace(PHP_EOL, "", $cert);
 


### PR DESCRIPTION
This insures that the certificate `preg_replace` cleanup works as expected.
for example if a certificate looks something like this:
```
-----BEGIN CERTIFICATE-----
LKASJDKLJFKLASDFKHADLKAS213412387KASLDHASDFJ1234123009AHDA08HD8Q
LKASJDKLJFKLASDFKHADLKAS213412387KASLDHASDFJ1234123009AHDA08HD8Q
LKASJDKLJFKLASDFKHADLKAS
-----END CERTIFICATE-----

```
without this fix, the `preg_replace` will not remove the `-----END CERTIFICATE-----` and the certificate in the metadata would look like this:
```
LKASJDKLJFKLASDFKHADLKAS213412387KASLDHASDFJ1234123009AHDA08HD8QLKASJDKLJFKLASDFKHADLKAS213412387KASLDHASDFJ1234123009AHDA08HD8QLKASJDKLJFKLASDFKHADLKAS-----END CERTIFICATE-----
```