### PR TITLE
initialize saml.slo session with empty array

### DIFF
--- a/src/Http/Controllers/LogoutController.php
+++ b/src/Http/Controllers/LogoutController.php
@@ -21,6 +21,10 @@ class LogoutController extends Controller
             $slo_redirect = $request->session()->get('saml.slo_redirect');
         }
 
+        if (null === $request->session()->get('saml.slo')) {
+            $request->session()->put('saml.slo', []);
+        }
+
         // Need to broadcast to our other SAML apps to log out!
         // Loop through our service providers and "touch" the logout URL's
         foreach (config('samlidp.sp') as $key => $sp) {

--- a/src/Listeners/SamlLogout.php
+++ b/src/Listeners/SamlLogout.php
@@ -16,7 +16,7 @@ class SamlLogout
     public function handle(Logout $event)
     {
         // Make sure we are not in the process of SLO when handling the redirect
-        if (in_array($event->guard, config('samlidp.guards')) && ! session('saml.slo')) {
+        if (in_array($event->guard, config('samlidp.guards')) && null === session('saml.slo')) {
             abort(redirect('saml/logout'), 200);
         }
     }


### PR DESCRIPTION
This prevents the logout listener from endless loops when no SP has logout
configured.

solves #36

(cherry picked from commit c5c23208ecb602bb845b0c054cf69067fd5b88ab)