### PR TITLE
Replace lightsaml/lightsaml with litesaml/lightsaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codegreencreative/laravel-samlidp",
-  "description": "Make your PHP Laravel application an Idenification Provider using SAML 2.0. This package allows you to implement your own Identification Provider (idP) using the SAML 2.0 standard to be used with supporting SAML 2.0 Service Providers (SP).",
+  "description": "Make your PHP Laravel application an Identification Provider using SAML 2.0. This package allows you to implement your own Identification Provider (idP) using the SAML 2.0 standard to be used with supporting SAML 2.0 Service Providers (SP).",
   "keywords": [
     "laravel",
     "saml",
@@ -15,7 +15,7 @@
     "php": "^7.2.5 | ^8.0",
     "illuminate/support": "^7.0 | ^8.0 | ^9.0",
     "illuminate/routing": "^7.0 | ^8.0 | ^9.0",
-    "lightsaml/lightsaml": "^2.3"
+    "litesaml/lightsaml": "^4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
On May 29th, 2022 in commit https://github.com/lightSAML/lightSAML/commit/22ac715f3feb499eaa5a8a61c9cd78ae468613f0 it was announced that the lightsaml/lightsaml library was no longer in active development, and to switch to using https://github.com/litesaml/lightsaml instead. 

- The new repository is by the same author.  
- Reviewed the changelog and there does not appear to be any breaking changes in the updates since May 29
- Tested with the implementation we're using, and authentication worked properly. 
