### PR TITLE
Allow default COMMON_NAME field to be configurable

### DIFF
--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -13,6 +13,8 @@ return [
     'debug' => false,
     // Define the email address field name in the users table
     'email_field' => 'email',
+    // Define the name field in the users table
+    'name_field' => 'name',
     // The URI to your login page
     'login_uri' => 'login',
     // Log out of the IdP after SLO

--- a/src/Events/Assertion.php
+++ b/src/Events/Assertion.php
@@ -30,6 +30,6 @@ class Assertion
         $this->attribute_statement = &$attribute_statement;
         $this->attribute_statement
             ->addAttribute(new Attribute(ClaimTypes::EMAIL_ADDRESS, auth($guard)->user()->__get(config('samlidp.email_field', 'email'))))
-            ->addAttribute(new Attribute(ClaimTypes::COMMON_NAME, auth($guard)->user()->name));
+            ->addAttribute(new Attribute(ClaimTypes::COMMON_NAME, auth($guard)->user()->__get(config('samlidp.name_field', 'name'))));
     }
 }


### PR DESCRIPTION
Just a quick change to allow the default COMMON_NAME field to be changed in the config.