### PR TITLE
Flexible NameID

### DIFF
--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -15,6 +15,8 @@ return [
     'email_field' => 'email',
     // Define the name field in the users table
     'name_field' => 'name',
+    // Defiine the NameID (optional)
+    // 'name_id_format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
     // The URI to your login page
     'login_uri' => 'login',
     // Log out of the IdP after SLO

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -15,6 +15,8 @@ return [
     'email_field' => 'email',
     // Define the name field in the users table
     'name_field' => 'name',
+    // Define whether or not to use NameID
+    'use_name_id' => true,
     // Defiine the NameID (optional)
     // 'name_id_format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
     // The URI to your login page

--- a/resources/views/metadata.blade.php
+++ b/resources/views/metadata.blade.php
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2027-01-20T19:04:25Z" cacheDuration="PT1485371065S" entityID="{{ url(config('samlidp.issuer_uri')) }}">
-  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2027-01-20T19:04:25Z"
+  cacheDuration="PT1485371065S" entityID="{{ url(config('samlidp.issuer_uri')) }}">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false"
+    protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <md:KeyDescriptor use="signing">
       <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
         <ds:X509Data>
@@ -15,7 +17,8 @@
         </ds:X509Data>
       </ds:KeyInfo>
     </md:KeyDescriptor>
-    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ url(config('samlidp.login_uri')) }}"/>
+    <md:NameIDFormat>{{ $nameIdFormat }}</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+      Location="{{ url(config('samlidp.login_uri')) }}" />
   </md:IDPSSODescriptor>
 </md:EntityDescriptor>

--- a/src/Events/Assertion.php
+++ b/src/Events/Assertion.php
@@ -29,7 +29,21 @@ class Assertion
     {
         $this->attribute_statement = &$attribute_statement;
         $this->attribute_statement
-            ->addAttribute(new Attribute(ClaimTypes::EMAIL_ADDRESS, auth($guard)->user()->__get(config('samlidp.email_field', 'email'))))
-            ->addAttribute(new Attribute(ClaimTypes::COMMON_NAME, auth($guard)->user()->__get(config('samlidp.name_field', 'name'))));
+            ->addAttribute(
+                new Attribute(
+                    ClaimTypes::EMAIL_ADDRESS,
+                    auth($guard)
+                        ->user()
+                        ->__get(config('samlidp.email_field', 'email'))
+                )
+            )
+            ->addAttribute(
+                new Attribute(
+                    ClaimTypes::COMMON_NAME,
+                    auth($guard)
+                        ->user()
+                        ->__get(config('samlidp.name_field', 'name'))
+                )
+            );
     }
 }

--- a/src/Http/Controllers/MetadataController.php
+++ b/src/Http/Controllers/MetadataController.php
@@ -2,6 +2,7 @@
 
 namespace CodeGreenCreative\SamlIdp\Http\Controllers;
 
+use LightSaml\SamlConstants;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Storage;
 
@@ -29,9 +30,11 @@ class MetadataController extends Controller
         }
 
         $cert = preg_replace('/^\W+\w+\s+\w+\W+\s(.*)\s+\W+.*$/s', '$1', trim($cert));
-        $cert = str_replace(PHP_EOL, "", $cert);
+        $cert = str_replace(PHP_EOL, '', $cert);
 
-        return response(view('samlidp::metadata', compact('cert')), 200, [
+        $nameIdFormat = config('samlidp.name_id_format', SamlConstants::NAME_ID_FORMAT_EMAIL);
+
+        return response(view('samlidp::metadata', compact('cert', 'nameIdFormat')), 200, [
             'Content-Type' => 'application/xml',
         ]);
     }

--- a/src/Jobs/SamlSlo.php
+++ b/src/Jobs/SamlSlo.php
@@ -2,26 +2,29 @@
 
 namespace CodeGreenCreative\SamlIdp\Jobs;
 
-use CodeGreenCreative\SamlIdp\Traits\PerformsSingleSignOn;
-use Illuminate\Foundation\Bus\Dispatchable;
 use LightSaml\Helper;
-use LightSaml\Model\Assertion\Issuer;
-use LightSaml\Model\Assertion\NameID;
-use LightSaml\Model\Context\DeserializationContext;
-use LightSaml\Model\Protocol\LogoutRequest;
-use LightSaml\Model\Protocol\LogoutResponse;
-use LightSaml\Model\Protocol\Status;
-use LightSaml\Model\Protocol\StatusCode;
-use LightSaml\Model\XmlDSig\SignatureWriter;
-use LightSaml\SamlConstants;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use LightSaml\SamlConstants;
+use LightSaml\Model\Protocol\Status;
+use LightSaml\Model\Assertion\Issuer;
+use LightSaml\Model\Assertion\NameID;
+use LightSaml\Model\Protocol\StatusCode;
+use Illuminate\Foundation\Bus\Dispatchable;
+use LightSaml\Model\Protocol\LogoutRequest;
+use LightSaml\Model\Protocol\LogoutResponse;
+use LightSaml\Model\XmlDSig\SignatureWriter;
+use LightSaml\Model\Context\DeserializationContext;
+use CodeGreenCreative\SamlIdp\Traits\PerformsSingleSignOn;
 
 class SamlSlo
 {
-    use Dispatchable, PerformsSingleSignOn;
+    use Dispatchable;
+    use PerformsSingleSignOn;
 
     private $sp;
+    private $destination;
+    private $logout_request;
 
     /**
      * [__construct description]
@@ -44,13 +47,13 @@ class SamlSlo
         // We are receiving a Logout Request
         if (request()->filled('SAMLRequest')) {
             $xml = gzinflate(base64_decode(request('SAMLRequest')));
-            $deserializationContext = new DeserializationContext;
+            $deserializationContext = new DeserializationContext();
             $deserializationContext->getDocument()->loadXML($xml);
             // Get the final destination
             session()->put('RelayState', request('RelayState'));
         } elseif (request()->filled('SAMLResponse')) {
             $xml = gzinflate(base64_decode(request('SAMLResponse')));
-            $deserializationContext = new DeserializationContext;
+            $deserializationContext = new DeserializationContext();
             $deserializationContext->getDocument()->loadXML($xml);
         }
         // Send the request to log out
@@ -63,15 +66,18 @@ class SamlSlo
      */
     public function response()
     {
-        $this->response = (new LogoutResponse)->setIssuer(new Issuer($this->issuer))
+        $this->response = (new LogoutResponse())
+            ->setIssuer(new Issuer($this->issuer))
             ->setID(Helper::generateID())
-            ->setIssueInstant(new \DateTime)
+            ->setIssueInstant(new \DateTime())
             ->setDestination($this->destination)
             ->setInResponseTo($this->logout_request->getId())
             ->setStatus(new Status(new StatusCode('urn:oasis:names:tc:SAML:2.0:status:Success')));
 
         if (config('samlidp.messages_signed')) {
-            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm));
+            $this->response->setSignature(
+                new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm)
+            );
         }
 
         return $this->send(SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
@@ -83,15 +89,17 @@ class SamlSlo
      */
     public function request()
     {
-        $this->response = (new LogoutRequest)
+        $this->response = (new LogoutRequest())
             ->setIssuer(new Issuer($this->issuer))
-            ->setNameID((new NameID(Helper::generateID(), SamlConstants::NAME_ID_FORMAT_TRANSIENT)))
+            ->setNameID(new NameID(Helper::generateID(), SamlConstants::NAME_ID_FORMAT_TRANSIENT))
             ->setID(Helper::generateID())
-            ->setIssueInstant(new \DateTime)
+            ->setIssueInstant(new \DateTime())
             ->setDestination($this->destination);
 
         if (config('samlidp.messages_signed')) {
-            $this->response->setSignature(new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm));
+            $this->response->setSignature(
+                new SignatureWriter($this->certificate, $this->private_key, $this->digest_algorithm)
+            );
         }
 
         return $this->send(SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
@@ -102,27 +110,26 @@ class SamlSlo
         $destination = $this->sp['logout'];
         $queryParams = $this->getQueryParams();
         if (!empty($queryParams)) {
-            if (!parse_url($destination, PHP_URL_QUERY)){
+            if (!parse_url($destination, PHP_URL_QUERY)) {
                 $destination = Str::finish(url($destination), '?') . Arr::query($queryParams);
-            }
-            else{
-                $destination .= '&'.Arr::query($queryParams);
+            } else {
+                $destination .= '&' . Arr::query($queryParams);
             }
         }
 
         $this->destination = $destination;
     }
 
-   private function getQueryParams()
-   {
-        $queryParams = (isset($this->sp['query_params']) ? $this->sp['query_params'] : null);
+    private function getQueryParams()
+    {
+        $queryParams = isset($this->sp['query_params']) ? $this->sp['query_params'] : null;
 
         if (is_null($queryParams)) {
             $queryParams = [
-                'idp' => config('app.url')
+                'idp' => config('app.url'),
             ];
         }
 
         return $queryParams;
-   }
+    }
 }


### PR DESCRIPTION
Changes made for NameID for SAML assertions and metadata XML page.

- Add two new options to the config file for setting NameID format (original default value is used if not set) and an option to turn off NameID altogether in assertions.
- Update metadata XML file to use dynamic NameID format from the config, if set.

This code has yet to be tested. Unfortunately, time is tight. If anyone has the time to give this a try, please do!