### PR TITLE
Add dependency on ext-zlib to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": "^7.2.5|^8.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/routing": "^7.0|^8.0|^9.0|^10.0",
-        "litesaml/lightsaml": "^4.0"
+        "litesaml/lightsaml": "^4.0",
+        "ext-zlib": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package makes use of gzinflate in SamlSlo which immediately means it has a dependency on the zlib extension