### PR TITLE
Allow setting block and key transport encryption algorithms on a per-SP basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 .DS_Store
 node_modules
+workbench

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:8.1-cli
+ARG GITHUB_TOKEN
+
+
+RUN apt update && apt install -y \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql
+
+RUN docker-php-ext-install pdo pdo_pgsql
+
+COPY --chown=www-data:www-data . /var/www
+
+WORKDIR /var/www
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer config -g github-oauth.github.com $GITHUB_TOKEN \
+    && composer install \
+    --no-interaction \
+    --no-plugins \
+    --no-scripts \
+    --prefer-dist \
+    --optimize-autoloader
+
+CMD php

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4",
-        "orchestra/testbench": "^8.15"
+        "orchestra/testbench": "^8.15",
+        "laravel/legacy-factories": "^1.0.4"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": {
-            "CodeGreenCreative\\SamlIdp\\": "src/"
+            "CodeGreenCreative\\SamlIdp\\": "src/",
+            "CodeGreenCreative\\SamlIdp\\Tests\\": "tests/"
         }
     },
     "extra": {
@@ -31,6 +32,31 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.4"
+        "phpunit/phpunit": "^10.4",
+        "orchestra/testbench": "^8.15"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Workbench\\App\\": "workbench/app/",
+            "Workbench\\Database\\Factories\\": "workbench/database/factories/",
+            "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
+        }
+    },
+    "scripts": {
+        "post-autoload-dump": [
+            "@clear",
+            "@prepare"
+        ],
+        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+        "prepare": "@php vendor/bin/testbench package:discover --ansi",
+        "build": "@php vendor/bin/testbench workbench:build --ansi",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "@build",
+            "@php vendor/bin/testbench serve"
+        ],
+        "test": [
+            "@php vendor/bin/phpunit"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
                 "CodeGreenCreative\\SamlIdp\\LaravelSamlIdpServiceProvider"
             ]
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-4": {
             "CodeGreenCreative\\SamlIdp\\": "src/",
-            "CodeGreenCreative\\SamlIdp\\Tests\\": "tests/"
+            "CodeGreenCreative\\SamlIdp\\Tests\\": "tests/",
+            "CodeGreenCreative\\SamlIdp\\Database\\Factories\\": "database/factories/"
         }
     },
     "extra": {

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -69,6 +69,6 @@ return [
     'guards' => ['web'],
 
     // Define the model used to store service provider configurations (if applicable)
-    'config_model_usage' => false,
-    'config_model' => \CodeGreenCreative\SamlIdp\Models\ServiceProvider::class
+    'service_provider_model_usage' => false,
+    'service_provider_model' => \CodeGreenCreative\SamlIdp\Models\ServiceProvider::class
 ];

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -67,4 +67,8 @@ return [
 
     // List of guards saml idp will catch Authenticated, Login and Logout events
     'guards' => ['web'],
+
+    // Define the model used to store service provider configurations (if applicable)
+    'config_model_usage' => false,
+    'config_model' => \CodeGreenCreative\SamlIdp\Src\Models\ServiceProvider::class
 ];

--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -70,5 +70,5 @@ return [
 
     // Define the model used to store service provider configurations (if applicable)
     'config_model_usage' => false,
-    'config_model' => \CodeGreenCreative\SamlIdp\Src\Models\ServiceProvider::class
+    'config_model' => \CodeGreenCreative\SamlIdp\Models\ServiceProvider::class
 ];

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -2,11 +2,14 @@
 
 namespace CodeGreenCreative\SamlIdp\Database\Factories;
 
+use CodeGreenCreative\SamlIdp\Models\ServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 class ServiceProviderFactory extends Factory
 {
+    protected $model = ServiceProvider::class;
+
     /**
      * Define the model's default state.
      *

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -1,13 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace Database\Factories;
+namespace CodeGreenCreative\SamlIdp\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
-/**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\CodeGreenCreative\SamlIdp\Models\ServiceProvider>
- */
 class ServiceProviderFactory extends Factory
 {
     /**
@@ -15,7 +12,7 @@ class ServiceProviderFactory extends Factory
      *
      * @return array<string, mixed>
      */
-    public function definition()
+    public function definition(): array
     {
         return [
             'destination_url' => $this->faker->url,

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\CodeGreenCreative\SamlIdp\Src\Models\ServiceProvider>
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\CodeGreenCreative\SamlIdp\Models\ServiceProvider>
  */
 class ServiceProviderFactory extends Factory
 {

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\CodeGreenCreative\SamlIdp\Src\Models\ServiceProvider>
+ */
+class ServiceProviderFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'destination_url' => $this->faker->url,
+            'logout_url' => $this->faker->url,
+            'certificate' => $this->faker->text(100),
+            'block_encryption_algorithm' => XMLSecurityKey::AES128_CBC,
+            'key_transport_encryption' => XMLSecurityKey::RSA_1_5,
+            'query_parameters' => false,
+            'encrypt_assertion' => false,
+        ];
+    }
+}

--- a/database/factories/ServiceProviderFactory.php
+++ b/database/factories/ServiceProviderFactory.php
@@ -3,28 +3,17 @@
 namespace CodeGreenCreative\SamlIdp\Database\Factories;
 
 use CodeGreenCreative\SamlIdp\Models\ServiceProvider;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
-class ServiceProviderFactory extends Factory
-{
-    protected $model = ServiceProvider::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition(): array
-    {
-        return [
-            'destination_url' => $this->faker->url,
-            'logout_url' => $this->faker->url,
-            'certificate' => $this->faker->text(100),
-            'block_encryption_algorithm' => XMLSecurityKey::AES128_CBC,
-            'key_transport_encryption' => XMLSecurityKey::RSA_1_5,
-            'query_parameters' => false,
-            'encrypt_assertion' => false,
-        ];
-    }
-}
+$factory->define(ServiceProvider::class, function () {
+    return [
+        'destination_url' => $this->faker->url,
+        'logout_url' => $this->faker->url,
+        'certificate' => $this->faker->text(100),
+        'block_encryption_algorithm' => XMLSecurityKey::AES128_CBC,
+        'key_transport_encryption' => XMLSecurityKey::RSA_1_5,
+        'query_parameters' => false,
+        'encrypt_assertion' => false,
+    ];
+});

--- a/database/migrations/2023_12_22_193224_create_service_providers_table.php
+++ b/database/migrations/2023_12_22_193224_create_service_providers_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('service_providers', function (Blueprint $table) {
             $table->id();
@@ -31,7 +31,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('service_providers');
     }

--- a/database/migrations/2023_12_22_193224_create_service_providers_table.php
+++ b/database/migrations/2023_12_22_193224_create_service_providers_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('service_providers', function (Blueprint $table) {
             $table->id();
-            $table->string('destination_url');
+            $table->string('destination_url')->unique();
             $table->string('logout_url');
             $table->string('certificate');
             $table->string('block_encryption_algorithm');

--- a/database/migrations/2023_12_22_193224_create_service_providers_table.php
+++ b/database/migrations/2023_12_22_193224_create_service_providers_table.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('service_providers', function (Blueprint $table) {
+            $table->id();
+            $table->string('destination_url');
+            $table->string('logout_url');
+            $table->string('certificate');
+            $table->string('block_encryption_algorithm');
+            $table->string('key_transport_encryption');
+            $table->boolean('query_parameters');
+            $table->boolean('encrypt_assertion');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('service_providers');
+    }
+};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3.4"
+services:
+    postgres:
+        image: postgres:13.6-alpine
+        environment:
+            POSTGRES_USER: testsuite
+            POSTGRES_PASSWORD: testsuite
+        healthcheck:
+            test: pg_isready
+
+    laravel-samlidp:
+        build:
+#            context: ./laravel-best
+#            target: php-dev
+            args:
+                GITHUB_TOKEN: $GITHUB_TOKEN
+#        image: 856220805142.dkr.ecr.us-east-1.amazonaws.com/bright/laravel-best:testing
+        depends_on:
+            postgres:
+                condition: service_healthy
+
+        volumes:
+            - .:/var/www

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
             args:
                 GITHUB_TOKEN: $GITHUB_TOKEN
 #        image: 856220805142.dkr.ecr.us-east-1.amazonaws.com/bright/laravel-best:testing
+        environment:
+            APP_KEY: AckfSECXIvnK5r28GVIWUAxmbBSjTsmF
         depends_on:
             postgres:
                 condition: service_healthy

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Contract">
+            <directory suffix="Test.php">./tests/Contract</directory>
+        </testsuite>
+
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/LaravelSamlIdpServiceProvider.php
+++ b/src/LaravelSamlIdpServiceProvider.php
@@ -72,6 +72,10 @@ class LaravelSamlIdpServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__ . '/../config/samlidp.php' => config_path('samlidp.php'),
             ], 'samlidp_config');
+
+            $this->publishes([
+                __DIR__ . '/../database/migrations' => database_path('migrations'),
+            ], 'samlidp_migrations');
         }
     }
 

--- a/src/Models/ServiceProvider.php
+++ b/src/Models/ServiceProvider.php
@@ -2,14 +2,10 @@
 
 namespace CodeGreenCreative\SamlIdp\Models;
 
-use CodeGreenCreative\SamlIdp\Database\Factories\ServiceProviderFactory;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ServiceProvider extends Model
 {
-    use HasFactory;
-
     protected $fillable = [
         'destination_url',
         'logout_url',
@@ -19,9 +15,4 @@ class ServiceProvider extends Model
         'query_parameters',
         'encrypt_assertion',
     ];
-
-    protected static function newFactory(): ServiceProviderFactory
-    {
-        return ServiceProviderFactory::new();
-    }
 }

--- a/src/Models/ServiceProvider.php
+++ b/src/Models/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace CodeGreenCreative\SamlIdp\Models;
 
+use CodeGreenCreative\SamlIdp\Database\Factories\ServiceProviderFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -18,4 +19,9 @@ class ServiceProvider extends Model
         'query_parameters',
         'encrypt_assertion',
     ];
+
+    protected static function newFactory(): ServiceProviderFactory
+    {
+        return ServiceProviderFactory::new();
+    }
 }

--- a/src/Models/ServiceProvider.php
+++ b/src/Models/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace CodeGreenCreative\SamlIdp\Src\Models;
+namespace CodeGreenCreative\SamlIdp\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Src/Models/ServiceProvider.php
+++ b/src/Src/Models/ServiceProvider.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace CodeGreenCreative\SamlIdp\Src\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ServiceProvider extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'destination_url',
+        'logout_url',
+        'certificate',
+        'block_encryption_algorithm',
+        'key_transport_encryption',
+        'query_parameters',
+        'encrypt_assertion',
+    ];
+}

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,20 @@
+providers:
+  # - Workbench\App\Providers\WorkbenchServiceProvider
+
+migrations:
+  - workbench/database/migrations
+
+seeders:
+  - Workbench\Database\Seeders\DatabaseSeeder
+
+workbench:
+  start: '/'
+  install: true
+  discovers:
+    web: true
+    api: false
+    commands: false
+    views: false
+  build: []
+  assets: []
+  sync: []

--- a/tests/ExampleTestCase.php
+++ b/tests/ExampleTestCase.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace CodeGreenCreative\SamlIdp\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+
+class ExampleTestCase extends TestCase
+{
+    #[Test]
+    public function basic_test(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/LogoutControllerTest.php
+++ b/tests/LogoutControllerTest.php
@@ -1,0 +1,164 @@
+<?php declare(strict_types=1);
+
+namespace CodeGreenCreative\SamlIdp\Tests;
+
+use CodeGreenCreative\SamlIdp\Jobs\SamlSlo;
+use CodeGreenCreative\SamlIdp\Models\ServiceProvider;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+class LogoutControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var User
+     */
+    public User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = new User();
+    }
+
+    /** @test */
+    public function dispatch_slo_for_service_provider_in_samlidp_config(): void
+    {
+        // Arrange
+        $destination = 'https://faketest.com';
+        $encodedAcsUrl = base64_encode($destination);
+        $fakeSPConfig = [
+            $encodedAcsUrl => [
+             'destination' => $destination,
+             'logout' => 'https://anotherfaketest.com',
+             'certificate' => '',
+             'query_params' => false,
+             'encrypt_assertion' => false
+            ]
+        ];
+
+        config(['samlidp.sp' => $fakeSPConfig]);
+
+        $sloMock = \Mockery::mock('overload:' . SamlSlo::class)->makePartial();
+
+        // Act
+        $this->actingAs($this->user)->get('/saml/logout');
+
+        // Assert
+        $sloMock->shouldHaveReceived('dispatchSync')->with($fakeSPConfig[$encodedAcsUrl]);
+    }
+
+    /** @test */
+    public function do_not_access_database_if_service_provider_model_usage_variable_is_not_configured(): void
+    {
+        // Arrange
+        $destination = 'https://faketest.com';
+        $encodedAcsUrl = base64_encode($destination);
+        $fakeSPConfig = [
+            $encodedAcsUrl => [
+                'destination' => $destination,
+                'logout' => 'https://anotherfaketest.com',
+                'certificate' => '',
+                'query_params' => false,
+                'encrypt_assertion' => false
+            ]
+        ];
+
+        config(['samlidp.sp' => $fakeSPConfig]);
+
+        // We do not want to actually run the slo job
+        $sloMock = \Mockery::mock('overload:' . SamlSlo::class);
+        DB::connection()->enableQueryLog();
+
+        // Act
+        $this->actingAs($this->user)->get('/saml/logout');
+
+        // Assert
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    /** @test */
+    public function do_not_access_database_if_service_provider_model_usage_variable_is_false(): void
+    {
+        // Arrange
+        config([
+            'samlidp.service_provider_model_usage' => false,
+        ]);
+
+        $destination = 'https://faketest.com';
+        $encodedAcsUrl = base64_encode($destination);
+        $fakeSPConfig = [
+            $encodedAcsUrl => [
+                'destination' => $destination,
+                'logout' => 'https://anotherfaketest.com',
+                'certificate' => '',
+                'query_params' => false,
+                'encrypt_assertion' => false
+            ]
+        ];
+
+        config(['samlidp.sp' => $fakeSPConfig]);
+
+        // We do not want to actually run the slo job
+        $sloMock = \Mockery::mock('overload:' . SamlSlo::class);
+        DB::connection()->enableQueryLog();
+
+        // Act
+        $this->actingAs($this->user)->get('/saml/logout');
+
+        // Assert
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    // The logout controller relies on service provider configurations to be saved to samlidp config. So, if we have
+    // service provider configurations saved to the db - we need to make sure that the configurations are added to the
+    // config file before the slo job is called.
+    /** @test */
+    public function add_sp_model_configurations_saved_in_the_database_to_samlidp_config(): void
+    {
+        // Arrange
+        config([
+            'samlidp.service_provider_model_usage' => true,
+            'samlidp.service_provider_model' => ServiceProvider::class,
+        ]);
+
+        $serviceProvider1 = factory(ServiceProvider::class)->create();
+        $serviceProvider2 = factory(ServiceProvider::class)->create();
+
+        // Act
+        $this->actingAs($this->user)->get('/saml/logout');
+
+        // Assert
+        $spConfig1 = [
+            'destination' => $serviceProvider1->destination_url,
+            'logout' => $serviceProvider1->logout_url,
+            'certificate' => $serviceProvider1->certificate,
+            'query_params' => $serviceProvider1->query_params,
+            'encrypt_assertion' => $serviceProvider1->encrypt_assertion,
+            'block_encryption_algorithm' => $serviceProvider1->block_encryption_algorithm,
+            'key_transport_encryption' => $serviceProvider1->key_transport_encryption,
+        ];
+
+        $spConfig2 = [
+            'destination' => $serviceProvider2->destination_url,
+            'logout' => $serviceProvider2->logout_url,
+            'certificate' => $serviceProvider2->certificate,
+            'query_params' => $serviceProvider2->query_params,
+            'encrypt_assertion' => $serviceProvider2->encrypt_assertion,
+            'block_encryption_algorithm' => $serviceProvider2->block_encryption_algorithm,
+            'key_transport_encryption' => $serviceProvider2->key_transport_encryption,
+        ];
+
+        $serviceProvidersInConfig = config('samlidp.sp');
+        $spEncoded = base64_encode($serviceProvider1->destination_url);
+        $this->assertArrayHasKey($spEncoded, $serviceProvidersInConfig);
+        $this->assertEquals($spConfig1, $serviceProvidersInConfig[$spEncoded]);
+
+
+        $spEncoded = base64_encode($serviceProvider2->destination_url);
+        $this->assertArrayHasKey($spEncoded, $serviceProvidersInConfig);
+        $this->assertEquals($spConfig2, $serviceProvidersInConfig[$spEncoded]);
+    }
+}

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -160,6 +160,38 @@ XML;
     }
 
     /** @test */
+    public function do_not_access_database_if_service_provider_model_usage_variable_is_false(): void
+    {
+        // Arrange
+        config([
+            'samlidp.service_provider_model_usage' => false,
+        ]);
+
+        $fakeSPConfig = [
+            'destination' => $this->fakeACS,
+            'logout' => 'https://anotherfaketest.com',
+            'certificate' => '',
+            'query_params' => false,
+            'encrypt_assertion' => false
+        ];
+        
+        $encodedAcsUrl = base64_encode($this->fakeACS);
+        config([
+            'samlidp.sp' => [
+                $encodedAcsUrl => $fakeSPConfig
+            ]
+        ]);
+
+        DB::connection()->enableQueryLog();
+
+        // Act
+        $samlResponse = (new SamlSso())->handle();
+
+        // Assert
+        $this->assertEmpty(DB::getQueryLog());
+    }
+
+    /** @test */
     public function create_response_using_service_provider_model_when_database_access_is_configured(): void
     {
         // Arrange

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -174,7 +174,7 @@ XML;
             'query_params' => false,
             'encrypt_assertion' => false
         ];
-        
+
         $encodedAcsUrl = base64_encode($this->fakeACS);
         config([
             'samlidp.sp' => [
@@ -199,8 +199,9 @@ XML;
             'samlidp.service_provider_model_usage' => true,
             'samlidp.service_provider_model' => ServiceProvider::class
         ]);
-        $serviceProvider = ServiceProvider::factory()->create([
-            'destination_url' => $this->fakeACS // This field HAS to match the ACS URL in the SAML request
+
+        $serviceProvider = factory(ServiceProvider::class)->create([
+            'destination_url' => $this->fakeACS
         ]);
 
         // Act
@@ -233,8 +234,8 @@ XML;
             ]
         ]);
 
-        $serviceProvider = ServiceProvider::factory()->create([
-            'destination_url' => $this->fakeACS // This field HAS to match the ACS URL in the SAML request
+        $serviceProvider = factory(ServiceProvider::class)->create([
+            'destination_url' => $this->fakeACS
         ]);
 
         // Act

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace CodeGreenCreative\SamlIdp\Tests;
+
+use CodeGreenCreative\SamlIdp\Jobs\SamlSso;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+
+class SamlSsoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var string
+     */
+    public string $certificate = '';
+
+    /**
+     * @var string
+     */
+    public string $key = '';
+
+    /**
+     * @var string
+     */
+    public string $fakeACS = 'https://test-example.com';
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createFakeCertificate();
+
+        config([
+            'samlidp.email_field' => 'email',
+            'samlidp.cert' => $this->certificate,
+            'samlidp.key' => $this->key,
+        ]);
+
+        // This job is dispatched in the middle of a request-response cycle - so we need to create the request that it's
+        // expecting with an authenticated user
+        $user = new User();
+        $user->email = 'fake_email'; // This email HAS to be set for the saml assertion to be created
+        $this->actingAs($user);
+
+        $request = Request::create('route-doesnt-matter-here', 'POST', ['SAMLRequest'=> $this->createFakeSamlRequest()]);
+        $this->swap('request', $request);
+    }
+
+    private function createFakeCertificate(): void
+    {
+        // create new private and public key
+        $res = openssl_pkey_new();
+
+        // generate a certificate signing request
+        $csr = openssl_csr_new([uniqid()], $res);
+
+        // sign CSR
+        $signing = openssl_csr_sign($csr, null, $res, 365, ['digest_alg'=>'sha256']);
+
+        // export the certificate and private key to string
+        openssl_x509_export($signing, $this->certificate);
+        openssl_pkey_export($res, $this->key);
+    }
+
+    private function createFakeSamlRequest(): string
+    {
+        $fakeSamlRequestXml = '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+ID="ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
+Version="2.0"
+ProviderName="SP test"
+IssueInstant="2014-07-16T23:52:45Z"
+Destination="http://idp.example.com/SSOService.php"
+ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+AssertionConsumerServiceURL="'.$this->fakeACS.'">
+<saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>
+<samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+AllowCreate="true" />
+<samlp:RequestedAuthnContext Comparison="exact">
+<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+</samlp:RequestedAuthnContext>
+</samlp:AuthnRequest>';
+
+        // gzip inflate
+        $gzSamlRequest = gzdeflate($fakeSamlRequestXml);
+
+        // base64 encode
+        return base64_encode($gzSamlRequest);
+    }
+
+
+    // The following test case is to ensure that when the 'service_provider_model_usage' config variable is not set,
+    // the SamlSso job will run as normal and use the configuration data provided in the config to create a response.
+    #[Test]
+    public function use_config_variables_to_create_response_when_database_access_config_variable_is_not_set(): void
+    {
+        // Arrange
+        $fakeSPConfig = [
+             'destination' => 'https://faketest.com',
+             'logout' => 'https://anotherfaketest.com',
+             'certificate' => '',
+             'query_params' => false,
+             'encrypt_assertion' => false
+        ];
+
+        $encodedAcsUrl = base64_encode($this->fakeACS);
+        config([
+            'samlidp.sp' => [
+                $encodedAcsUrl => $fakeSPConfig
+            ]
+        ]);
+
+        // Act
+        $samlResponse = (new SamlSso())->handle();
+
+        // Assert
+        $this->assertNotNull($samlResponse);
+
+        $expectedFormTag = '<form method="post" action="' . $fakeSPConfig['destination'] .'">';
+        $this->assertTrue(str_contains($samlResponse, $expectedFormTag));
+    }
+}

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -65,23 +65,25 @@ class SamlSsoTest extends TestCase
 
     private function createFakeSamlRequest(): string
     {
-        $fakeSamlRequestXml = '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-ID="ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
-Version="2.0"
-ProviderName="SP test"
-IssueInstant="2014-07-16T23:52:45Z"
-Destination="http://idp.example.com/SSOService.php"
-ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-AssertionConsumerServiceURL="'.$this->fakeACS.'">
-<saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>
-<samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-AllowCreate="true" />
-<samlp:RequestedAuthnContext Comparison="exact">
-<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
-</samlp:RequestedAuthnContext>
-</samlp:AuthnRequest>';
-
+        $fakeSamlRequestXml = <<<XML
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+         xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+         ID="ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
+         Version="2.0"
+         ProviderName="SP test"
+         IssueInstant="2014-07-16T23:52:45Z"
+         Destination="http://idp.example.com/SSOService.php"
+         ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+         AssertionConsumerServiceURL="$this->fakeACS">
+         <saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>
+         <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+         AllowCreate="true" />
+         <samlp:RequestedAuthnContext Comparison="exact">
+         <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+         </samlp:RequestedAuthnContext>
+         </samlp:AuthnRequest>
+XML;
+        
         // gzip inflate
         $gzSamlRequest = gzdeflate($fakeSamlRequestXml);
 
@@ -93,11 +95,11 @@ AllowCreate="true" />
     // The following test case is to ensure that when the 'service_provider_model_usage' config variable is not set,
     // the SamlSso job will run as normal and use the configuration data provided in the config to create a response.
     #[Test]
-    public function use_config_variables_to_create_response_when_database_access_config_variable_is_not_set(): void
+    public function create_saml_response_using_samlidp_config(): void
     {
         // Arrange
         $fakeSPConfig = [
-             'destination' => 'https://faketest.com',
+             'destination' => $this->fakeACS,
              'logout' => 'https://anotherfaketest.com',
              'certificate' => '',
              'query_params' => false,

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -104,6 +104,8 @@ AllowCreate="true" />
              'encrypt_assertion' => false
         ];
 
+        // We HAVE to keep the exact format given in the config, i.e (encoded ACS URL => SP configuration)
+        // Otherwise the SamlSso job will not be able to find the correct service provider configuration
         $encodedAcsUrl = base64_encode($this->fakeACS);
         config([
             'samlidp.sp' => [

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -4,14 +4,11 @@ namespace CodeGreenCreative\SamlIdp\Tests;
 
 use CodeGreenCreative\SamlIdp\Jobs\SamlSso;
 use Illuminate\Foundation\Auth\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\Test;
 
 class SamlSsoTest extends TestCase
 {
-    use RefreshDatabase;
-
     /**
      * @var string
      */

--- a/tests/SamlSsoTest.php
+++ b/tests/SamlSsoTest.php
@@ -83,7 +83,7 @@ class SamlSsoTest extends TestCase
          </samlp:RequestedAuthnContext>
          </samlp:AuthnRequest>
 XML;
-        
+
         // gzip inflate
         $gzSamlRequest = gzdeflate($fakeSamlRequestXml);
 
@@ -94,7 +94,7 @@ XML;
 
     // The following test case is to ensure that when the 'service_provider_model_usage' config variable is not set,
     // the SamlSso job will run as normal and use the configuration data provided in the config to create a response.
-    #[Test]
+    /** @test */
     public function create_saml_response_using_samlidp_config(): void
     {
         // Arrange

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,12 @@ use \Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withFactories(__DIR__ . '/../database/factories');
+    }
     /**
      * Get package providers.
      *
@@ -40,5 +46,15 @@ abstract class TestCase extends OrchestraTestCase
             'prefix' => '',
             'schema' => 'public',
         ]);
+    }
+
+    /**
+     * Define database migrations.
+     *
+     * @return void
+     */
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace CodeGreenCreative\SamlIdp\Tests;
 
-abstract class TestCase extends \Orchestra\Testbench\TestCase
+use \Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+abstract class TestCase extends OrchestraTestCase
 {
     //
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,43 @@
 
 namespace CodeGreenCreative\SamlIdp\Tests;
 
+use CodeGreenCreative\SamlIdp\LaravelSamlIdpServiceProvider;
 use \Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
-    //
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array<int, class-string<\Illuminate\Support\ServiceProvider>>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            LaravelSamlIdpServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'pgsql');
+        $app['config']->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => 'postgres',
+            'port' => '5432',
+            'database' => 'testsuite',
+            'username' => 'testsuite',
+            'password' => 'testsuite',
+            'charset' => 'utf8',
+            'prefix' => '',
+            'schema' => 'public',
+        ]);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CodeGreenCreative\SamlIdp\Tests;
+
+abstract class TestCase extends \Orchestra\Testbench\TestCase
+{
+    //
+}


### PR DESCRIPTION
Currently, the package news up a `EncryptedAssertionWriter` which extends the abstract class `EncryptedElementWriter` which defaults to AES128_CBC for the block encryption algorithm and RSA_1_5 for key transport encryption.

In this PR, I added optional config variables that are read on a per-SP basis that allow changing these two algorithms.

Existing users implementations should not be broken by this change as written - but I'm working on adding a test suite to this package for future changes.