### PR TITLE
Make email name id configurable

### DIFF
--- a/config/samlidp.php
+++ b/config/samlidp.php
@@ -1,5 +1,7 @@
 <?php
 
+use LightSaml\SamlConstants;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -13,6 +15,8 @@ return [
     'debug' => false,
     // Define the email address field name in the users table
     'email_field' => 'email',
+    // Define the Name ID for the email field.
+    'email_name_id'=> SamlConstants::NAME_ID_FORMAT_EMAIL,
     // Define the name field in the users table
     'name_field' => 'name',
     // The URI to your login page

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -97,7 +97,7 @@ class SamlSso implements SamlContract
                             auth($this->guard)
                                 ->user()
                                 ->__get(config('samlidp.email_field', 'email')),
-                            SamlConstants::NAME_ID_FORMAT_EMAIL
+                            config('samlidp.email_name_id', SamlConstants::NAME_ID_FORMAT_EMAIL)
                         )
                     )
                     ->addSubjectConfirmation(


### PR DESCRIPTION
We were using a key cloak/aws cognito setup connected with SAML2, we had the problem that we had to change the name ID o f the application code.

We had to change the name ID. this would allow us not to keep a fork of your package, I would love to have this merged :) 