### PR TITLE
Add option to skip interaction when using `php artisan samlidp:cert`

### DIFF
--- a/src/Console/CreateCertificate.php
+++ b/src/Console/CreateCertificate.php
@@ -13,6 +13,8 @@ class CreateCertificate extends Command
      */
     protected $signature = 'samlidp:cert
                             {--days=7300 : Number of days to add from today as the expiration date}
+                            {--subject= : Subj input for OpenSSL request command}
+                            {--overwrite=0 : Overwrite existing PEM files without asking}
                             {--keyname=key.pem : Full name of the certificate key file}
                             {--certname=cert.pem : Full name to the certificate file}';
 
@@ -44,6 +46,7 @@ class CreateCertificate extends Command
         $days = $this->option('days');
         $keyname = $this->option('keyname');
         $certname = $this->option('certname');
+        $subject = $this->option('subject');
 
         // Create storage/samlidp directory
         if (!file_exists($storagePath)) {
@@ -52,10 +55,31 @@ class CreateCertificate extends Command
 
         $key = sprintf('%s/%s', $storagePath, $keyname);
         $cert = sprintf('%s/%s', $storagePath, $certname);
-        $question = 'The name chosen for the PEM files already exist. Would you like to overwrite existing PEM files?';
-        if ((!file_exists($key) && !file_exists($cert)) || $this->confirm($question)) {
+        if ($this->canCreateFiles($key, $cert)) {
             $command = 'openssl req -x509 -sha256 -nodes -days %s -newkey rsa:2048 -keyout %s -out %s';
+            if ($subject) {
+                $command .= ' -subj "' . $subject . '"';
+            }
+
             exec(sprintf($command, $days, $key, $cert));
         }
+    }
+
+    /**
+     * @param string $key
+     * @param string $cert
+     * @return bool
+     */
+    protected function canCreateFiles($key, $cert)
+    {
+        $anyFileExists = file_exists($key) || file_exists($cert);
+        if(!$anyFileExists) {
+            return true;
+        }
+        if($this->option('overwrite')) {
+            return true;
+        }
+        $question = 'The name chosen for the PEM files already exist. Would you like to overwrite existing PEM files?';
+        return $this->confirm($question);
     }
 }


### PR DESCRIPTION
We used to use the command `php artisan samlidp:cert` in a process, that did not have interactivity. The process would hanging because a question was asked.

## Added
* `samlidp:cert` --overwrite option to skip the question to overwrite cert files
* `samlidp:cert` --subject to add subject name when generating certificates