### PR TITLE
Fix 'syntax error, unexpected identifier "version"'

### DIFF
--- a/resources/views/metadata.blade.php
+++ b/resources/views/metadata.blade.php
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="2027-01-20T19:04:25Z" cacheDuration="PT1485371065S" entityID="{{ url(config('samlidp.issuer_uri')) }}">
   <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <md:KeyDescriptor use="signing">


### PR DESCRIPTION
Fix for systems that have `short_open_tag=On` by default like Laravel Vapor's default image.

Additional info: https://laracasts.com/discuss/channels/laravel/syntax-error-unexpected-identifier-version-1