### PR TITLE
Add ability to store SAML Service Providers in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,27 @@ return [
 ];
 ```
 
+#### Setting the service providers to be read from the database
+
+Run migrations
+
+```bash
+php artisan migrate
+```
+
+Add a service provider to the database table `saml_service_providers`. The database table follows the same principles
+as the config file.
+
+```php
+<?php
+
+return [
+    // ...
+    'sp' => \CodeGreenCreative\SamlIdp\Models\SamlServiceProvider::class,
+    // ...
+];
+```
+
 ### Setting the service provider certificate
 
 There are three options to set the service provider certificate.

--- a/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
+++ b/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('saml_service_providers', function (Blueprint $table) {
+        Schema::create('laravel_samlidp_service_providers', function (Blueprint $table) {
             $table->string('id')->unique()->comment('acs_url base64 encoded');
             $table->text('acs_url');
             $table->text('destination');

--- a/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
+++ b/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
@@ -13,9 +13,9 @@ return new class extends Migration
     {
         Schema::create('saml_service_providers', function (Blueprint $table) {
             $table->string('id')->unique()->comment('acs_url base64 encoded');
-            $table->string('acs_url');
-            $table->string('destination');
-            $table->string('logout');
+            $table->text('acs_url');
+            $table->text('destination');
+            $table->text('logout');
             $table->longText('certificate');
             $table->boolean('query_params');
             $table->boolean('encrypt_assertion');

--- a/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
+++ b/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
@@ -12,8 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('saml_service_providers', function (Blueprint $table) {
-            $table->id();
-            $table->string('acs_url_encoded');
+            $table->string('id')->unique()->comment('acs_url base64 encoded');
             $table->string('acs_url');
             $table->string('destination');
             $table->string('logout');
@@ -22,7 +21,7 @@ return new class extends Migration
             $table->boolean('encrypt_assertion');
             $table->timestamps();
 
-            $table->index('acs_url_encoded');
+            $table->primary('id');
         });
     }
 

--- a/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
+++ b/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('saml_service_providers', function (Blueprint $table) {
+            $table->id();
+            $table->string('acs_url_encoded');
+            $table->string('acs_url');
+            $table->string('destination');
+            $table->string('logout');
+            $table->longText('certificate');
+            $table->boolean('query_params');
+            $table->boolean('encrypt_assertion');
+            $table->timestamps();
+
+            $table->index('acs_url_encoded');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('saml_service_providers');
+    }
+};

--- a/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
+++ b/database/migrations/2025_01_29_095333_create_saml_service_providers_table.php
@@ -30,6 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('saml_service_providers');
+        Schema::dropIfExists('laravel_samlidp_service_providers');
     }
 };

--- a/src/Http/Controllers/LogoutController.php
+++ b/src/Http/Controllers/LogoutController.php
@@ -2,6 +2,7 @@
 
 namespace CodeGreenCreative\SamlIdp\Http\Controllers;
 
+use CodeGreenCreative\SamlIdp\Traits\PerformsSingleSignOn;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -9,6 +10,8 @@ use CodeGreenCreative\SamlIdp\Jobs\SamlSlo;
 
 class LogoutController extends Controller
 {
+    use PerformsSingleSignOn;
+
     /**
      * [index description]
      * @return [type] [description]
@@ -27,7 +30,7 @@ class LogoutController extends Controller
 
         // Need to broadcast to our other SAML apps to log out!
         // Loop through our service providers and "touch" the logout URL's
-        foreach (config('samlidp.sp') as $key => $sp) {
+        foreach ($this->getAllServiceProviders() as $key => $sp) {
             // Check if the service provider supports SLO
             if (!empty($sp['logout']) && !in_array($key, $request->session()->get('saml.slo', []))) {
                 // Push this SP onto the saml slo array

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -172,7 +172,7 @@ class SamlSso implements SamlContract
 
     private function setDestination()
     {
-        $destination = config(sprintf('samlidp.sp.%s.destination', $this->getServiceProvider($this->authn_request)));
+        $destination = $this->getServiceProviderConfigValue($this->authn_request, 'destination');
 
         if (empty($destination)) {
             throw new DestinationMissingException(
@@ -197,7 +197,7 @@ class SamlSso implements SamlContract
 
     private function getQueryParams()
     {
-        $queryParams = config(sprintf('samlidp.sp.%s.query_params', $this->getServiceProvider($this->authn_request)));
+        $queryParams = $this->getServiceProviderConfigValue($this->authn_request, 'query_params');
 
         if (is_null($queryParams)) {
             $queryParams = [
@@ -210,7 +210,7 @@ class SamlSso implements SamlContract
 
     private function getSpCertificate()
     {
-        $spCertificate = config(sprintf('samlidp.sp.%s.certificate', $this->getServiceProvider($this->authn_request)));
+        $spCertificate = $this->getServiceProviderConfigValue($this->authn_request, 'certificate');
 
         return strpos($spCertificate, 'file://') === 0
             ? X509Certificate::fromFile($spCertificate)
@@ -225,7 +225,7 @@ class SamlSso implements SamlContract
     private function encryptAssertion(): bool
     {
         return config(
-            sprintf('samlidp.sp.%s.encrypt_assertion', $this->getServiceProvider($this->authn_request)),
+            $this->getServiceProviderConfigValue($this->authn_request, 'encrypt_assertion'),
             config('samlidp.encrypt_assertion', true)
         );
     }

--- a/src/LaravelSamlIdpServiceProvider.php
+++ b/src/LaravelSamlIdpServiceProvider.php
@@ -30,6 +30,7 @@ class LaravelSamlIdpServiceProvider extends ServiceProvider
     {
         $this->registerEvents();
         $this->registerRoutes();
+        $this->registerMigrations();
         $this->registerResources();
         $this->registerBladeComponents();
     }
@@ -149,5 +150,12 @@ class LaravelSamlIdpServiceProvider extends ServiceProvider
                 CreateServiceProvider::class,
             ]);
         }
+    }
+
+    private function registerMigrations()
+    {
+        $this->publishesMigrations([
+            __DIR__.'/../database/migrations' => database_path('migrations'),
+        ]);
     }
 }

--- a/src/Models/SamlServiceProvider.php
+++ b/src/Models/SamlServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class SamlServiceProvider extends Model
 {
+    protected $table = 'laravel_samlidp_service_providers';
     public $incrementing = false;
     protected $keyType = 'string';
 }

--- a/src/Models/SamlServiceProvider.php
+++ b/src/Models/SamlServiceProvider.php
@@ -6,5 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class SamlServiceProvider extends Model
 {
-
+    public $incrementing = false;
+    protected $keyType = 'string';
 }

--- a/src/Models/SamlServiceProvider.php
+++ b/src/Models/SamlServiceProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CodeGreenCreative\SamlIdp\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SamlServiceProvider extends Model
+{
+
+}

--- a/src/Traits/PerformsSingleSignOn.php
+++ b/src/Traits/PerformsSingleSignOn.php
@@ -88,7 +88,7 @@ trait PerformsSingleSignOn
 
     protected function getServiceProviderConfigValue($request, string $configKey): mixed
     {
-        if (config('samlidp.sp') instanceof SamlServiceProvider) {
+        if (config('samlidp.sp') === SamlServiceProvider::class) {
             $serviceProvider = SamlServiceProvider::where('encoded_acs_url', $this->getServiceProvider($request))
                 ->firstOrFail();
 
@@ -100,7 +100,7 @@ trait PerformsSingleSignOn
 
     public function getAllServiceProviders(): array
     {
-        if (config('samlidp.sp') instanceof SamlServiceProvider) {
+        if (config('samlidp.sp') === SamlServiceProvider::class) {
             return SamlServiceProvider::all()->toArray();
         }
 

--- a/src/Traits/PerformsSingleSignOn.php
+++ b/src/Traits/PerformsSingleSignOn.php
@@ -89,8 +89,7 @@ trait PerformsSingleSignOn
     protected function getServiceProviderConfigValue($request, string $configKey): mixed
     {
         if (config('samlidp.sp') === SamlServiceProvider::class) {
-            $serviceProvider = SamlServiceProvider::where('encoded_acs_url', $this->getServiceProvider($request))
-                ->firstOrFail();
+            $serviceProvider = SamlServiceProvider::findOrFail($this->getServiceProvider($request));
 
             return $serviceProvider->$configKey;
         }

--- a/src/Traits/PerformsSingleSignOn.php
+++ b/src/Traits/PerformsSingleSignOn.php
@@ -2,6 +2,7 @@
 
 namespace CodeGreenCreative\SamlIdp\Traits;
 
+use CodeGreenCreative\SamlIdp\Models\SamlServiceProvider;
 use Illuminate\Support\Facades\Storage;
 use LightSaml\Binding\BindingFactory;
 use LightSaml\Context\Profile\MessageContext;
@@ -83,5 +84,26 @@ trait PerformsSingleSignOn
         $key = config('samlidp.key') ?: Storage::disk('samlidp')->get(config('samlidp.keyname', 'key.pem'));
 
         return KeyHelper::createPrivateKey($key, '', strpos($key, 'file://') === 0, XMLSecurityKey::RSA_SHA256);
+    }
+
+    protected function getServiceProviderConfigValue($request, string $configKey): mixed
+    {
+        if (config('samlidp.sp') instanceof SamlServiceProvider) {
+            $serviceProvider = SamlServiceProvider::where('encoded_acs_url', $this->getServiceProvider($request))
+                ->firstOrFail();
+
+            return $serviceProvider->$configKey;
+        }
+
+        return config(sprintf('samlidp.sp.%s.%s', $this->getServiceProvider($request), $configKey));
+    }
+
+    public function getAllServiceProviders(): array
+    {
+        if (config('samlidp.sp') instanceof SamlServiceProvider) {
+            return SamlServiceProvider::all()->toArray();
+        }
+
+        return config('samlidp.sp');
     }
 }


### PR DESCRIPTION
This PR adds the functionality allowing you to declare service providers within the database rather than a fixed config file.

To use the database instead, set the `samlidp.sp` to be `\CodeGreenCreative\SamlIdp\Models\SamlServiceProvider::class` instead of the config array.