### PR TITLE
Fix not properly reading encrypt_assertion from provider config

### DIFF
--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -224,12 +224,7 @@ class SamlSso implements SamlContract
      */
     private function encryptAssertion(): bool
     {
-        $encryptAssertion = $this->getServiceProviderConfigValue($this->authn_request, 'encrypt_assertion');
-
-        if(is_null($encryptAssertion)) {
-            $encryptAssertion = config('samlidp.encrypt_assertion', true);
-        }
-
-        return $encryptAssertion;
+        return $this->getServiceProviderConfigValue($this->authn_request, 'encrypt_assertion')
+            ?? config('samlidp.encrypt_assertion', true);
     }
 }

--- a/src/Jobs/SamlSso.php
+++ b/src/Jobs/SamlSso.php
@@ -224,9 +224,12 @@ class SamlSso implements SamlContract
      */
     private function encryptAssertion(): bool
     {
-        return config(
-            $this->getServiceProviderConfigValue($this->authn_request, 'encrypt_assertion'),
-            config('samlidp.encrypt_assertion', true)
-        );
+        $encryptAssertion = $this->getServiceProviderConfigValue($this->authn_request, 'encrypt_assertion');
+
+        if(is_null($encryptAssertion)) {
+            $encryptAssertion = config('samlidp.encrypt_assertion', true);
+        }
+
+        return $encryptAssertion;
     }
 }


### PR DESCRIPTION
In #153, support was added to read config from database, this was done mostly right, however, when reading the `encrypt_assertion` value, instead of building the config key with `sprintf` it puts the value directly in the `config(...)` function. See: https://github.com/codegreencreative/laravel-samlidp/commit/70128a887a27c2a8c5690e149531bd9aa98971bf#diff-8e9d4a983d809c169a73e850f4ac9b3c294a018fd98a23ae4f686e33ab5cdb63L228

This PR fixes that.

