### PR TITLE
Allow for custom SP models

### DIFF
--- a/src/Traits/PerformsSingleSignOn.php
+++ b/src/Traits/PerformsSingleSignOn.php
@@ -88,8 +88,8 @@ trait PerformsSingleSignOn
 
     protected function getServiceProviderConfigValue($request, string $configKey): mixed
     {
-        if (config('samlidp.sp') === SamlServiceProvider::class) {
-            $serviceProvider = SamlServiceProvider::findOrFail($this->getServiceProvider($request));
+        if (!is_array(config('samlidp.sp'))) {
+            $serviceProvider = config('samlidp.sp')::findOrFail($this->getServiceProvider($request));
 
             return $serviceProvider->$configKey;
         }


### PR DESCRIPTION
As you may know, the config file allows for defining a class instead of an array to allow for the package to use a database as its source of Service Provider configurations.

However, upon tinkering, I realised that even though a class is passed as the configuration value, the class itself is actually disregarded and is just used as a constant to trigger the mechanism that checks the database. In other words, if you use a custom Service Provider model even with compatible fields, and pass that model into samlidp.sp, the database code will not trigger since it is not the built-in one.